### PR TITLE
fix: manifest.json に tabs パーミッションを追加

### DIFF
--- a/cloudformation_reflesher/manifest.json
+++ b/cloudformation_reflesher/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.1.1",
   "description": "AWS コンソール画面の自動更新を行う拡張機能",
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "tabs"
   ],
   "action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
## 概要\n\nClose #7\n\n`chrome.tabs.query()` で `tab.url` を取得するために必要な `tabs` パーミッションを追加。\n\n## 変更内容\n\n- `manifest.json`: `permissions` に `"tabs"` を追加