### PR TITLE
fix: URLチェックを AWSコンソール全体対応に修正

### DIFF
--- a/cloudformation_reflesher/popup.js
+++ b/cloudformation_reflesher/popup.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error('アクティブなタブが見つかりません');
       }
       // URLチェックを追加
-      if (!tab.url || (!tab.url.includes('console.aws.amazon.com') || !tab.url.includes('cloudformation'))) {
+      if (!tab.url || !tab.url.includes('console.aws.amazon.com')) {
         throw new Error('このページでは利用できません');
       }
       debugLog('タブ情報:', tab);


### PR DESCRIPTION
## 概要\n\nClose #8\n\nCloudFormation 限定だった URL チェックを削除し、AWSコンソール全体で動作するよう修正。\n\n## 変更内容\n\n- `popup.js`: `getCurrentTab()` の URL チェックから `cloudformation` の条件を削除